### PR TITLE
Add alias for GIMP 2.10

### DIFF
--- a/autoname_workspaces.py
+++ b/autoname_workspaces.py
@@ -67,6 +67,7 @@ WINDOW_ICONS = {
     'filezilla': fa.icons['server'],
     'firefox': fa.icons['firefox'],
     'firefox-esr': fa.icons['firefox'],
+    'gimp': fa.icons['image'],
     'gimp-2.8': fa.icons['image'],
     'gnome-control-center': fa.icons['toggle-on'],
     'gnome-terminal-server': fa.icons['terminal'],


### PR DESCRIPTION
GIMP 2.10 uses `gimp` as the classname
rather than `gimp-2.8` which was used for GIMP 2.8